### PR TITLE
Update python version and pytest invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 sudo: false
-python: 3.4
+python: 3.5
 addons:
   postgresql: "9.4"
 install:
@@ -8,5 +8,5 @@ install:
   - pip install -r requirements.txt
 script:
   - flake8 decisions paatos
-  - py.test -vvv --cov decisions
+  - pytest -vvv --cov decisions
 after_success: coveralls


### PR DESCRIPTION
3.5 is latest release, and py.test is deprecated https://docs.pytest.org/en/latest/faq.html#why-can-i-use-both-pytest-and-py-test-commands