### PR TITLE
Use slugrelatedfield for organizationclass datasource

### DIFF
--- a/decisions/api/organization.py
+++ b/decisions/api/organization.py
@@ -5,7 +5,7 @@ from decisions.models import Event, Organization, OrganizationClass, Post
 from .base import DataModelSerializer
 
 
-class OrganizationClassSerializer(serializers.ModelSerializer):
+class OrganizationClassSerializer(DataModelSerializer):
     class Meta:
         model = OrganizationClass
         fields = '__all__'


### PR DESCRIPTION
I would very much like `OrganizationClass` to report its `data_source` in the api the same way `Organization` does, so I can import the data consistently, now that these extra fields have appeared in the api.